### PR TITLE
Fix for profile path not matching username in case of renamed accounts

### DIFF
--- a/CMS2018 Save Editor/Helper.vb
+++ b/CMS2018 Save Editor/Helper.vb
@@ -1,6 +1,6 @@
 ﻿Module Helper
 
-    Public SaveGameDir As String = $"C:\Users\{Environment.UserName}\appdata\locallow\Red Dot Games\Car Mechanic Simulator 2018"
+    Public SaveGameDir As String = $"{Environment.GetEnvironmentVariable("USERPROFILE")}\appdata\locallow\Red Dot Games\Car Mechanic Simulator 2018"
     Public GlobalData As String = "GlobalData.dat"
 
 End Module


### PR DESCRIPTION
In some windows accounts which are converted from online mail account or corporate accounts username will not match the "C:\users\<profile_folder". This change is to use "Environment.GetEnvironmentVariable("USERPROFILE")" rather the username.